### PR TITLE
Fixed version numbers (3.0.0)

### DIFF
--- a/Billing/pom.xml
+++ b/Billing/pom.xml
@@ -7,7 +7,7 @@
     <groupId>ch.icclab.cyclops.billing</groupId>
     <artifactId>cyclops-billing</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.0</version>
+    <version>3.0.0</version>
     <name>Billing</name>
 
     <properties>

--- a/CDR/pom.xml
+++ b/CDR/pom.xml
@@ -7,7 +7,7 @@
     <groupId>ch.icclab.cyclops.cdr</groupId>
     <artifactId>cyclops-cdr</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.0</version>
+    <version>3.0.0</version>
     <name>CDR</name>
 
     <properties>

--- a/UDR/pom.xml
+++ b/UDR/pom.xml
@@ -7,7 +7,7 @@
     <groupId>ch.icclab.cyclops.udr</groupId>
     <artifactId>cyclops-udr</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.0</version>
+    <version>3.0.0</version>
     <name>UDR</name>
 
     <properties>


### PR DESCRIPTION
They were partially reverted in https://github.com/icclab/cyclops/commit/61608addc628d506ea153a1cfb618b9364270ffc causing the build scripts to fail.