### PR TITLE
Remove unreachable repository

### DIFF
--- a/Billing/pom.xml
+++ b/Billing/pom.xml
@@ -93,11 +93,6 @@
             <name>Public online Restlet repository</name>
             <url>http://maven.restlet.com</url>
         </repository>
-        <repository>
-            <id>maven-xpp3</id>
-            <name>Public online XPP3 repository</name>
-            <url>https://teamcity-systeme.lip6.fr/nexus/content/groups/public</url>
-        </repository>
     </repositories>
 
     <dependencies>

--- a/Coin/pom.xml
+++ b/Coin/pom.xml
@@ -110,11 +110,6 @@
             <name>Public online Restlet repository</name>
             <url>http://maven.restlet.com</url>
         </repository>
-        <repository>
-            <id>maven-xpp3</id>
-            <name>Public online XPP3 repository</name>
-            <url>https://teamcity-systeme.lip6.fr/nexus/content/groups/public</url>
-        </repository>
     </repositories>
 
     <dependencies>

--- a/UDR/pom.xml
+++ b/UDR/pom.xml
@@ -94,11 +94,6 @@
             <name>Public online Restlet repository</name>
             <url>http://maven.restlet.com</url>
         </repository>
-        <repository>
-            <id>maven-xpp3</id>
-            <name>Public online XPP3 repository</name>
-            <url>https://teamcity-systeme.lip6.fr/nexus/content/groups/public</url>
-        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
The repository `https://teamcity-systeme.lip6.fr/nexus/content/groups/public` is not accessible, which caused the `mvn dependency:tree` command to not be completed on the UDR, Coin and Billing modules